### PR TITLE
Refactoring triangle generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,120 +1,33 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(ros_assignments)
 
-## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   std_msgs
   message_generation
 )
 
-## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
+add_service_files(
+  FILES
+  ServiceCall.srv
+  InputService.srv 
+  StateService.srv
+)
 
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+)
 
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-# catkin_python_setup()
-
-################################################
-## Declare ROS messages, services and actions ##
-################################################
-
-## To declare and build messages, services or actions from within this
-## package, follow these steps:
-## * Let MSG_DEP_SET be the set of packages whose message types you use in
-##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
-## * In the file package.xml:
-##   * add a build_depend tag for "message_generation"
-##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
-##     but can be declared for certainty nonetheless:
-##     * add a run_depend tag for "message_runtime"
-## * In this file (CMakeLists.txt):
-##   * add "message_generation" and every package in MSG_DEP_SET to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * add "message_runtime" and every package in MSG_DEP_SET to
-##     catkin_package(CATKIN_DEPENDS ...)
-##   * uncomment the add_*_files sections below as needed
-##     and list every .msg/.srv/.action file to be processed
-##   * uncomment the generate_messages entry below
-##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
-
-## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
-
-## Generate services in the 'srv' folder
- add_service_files(
-   FILES
-   ServiceCall.srv
-   InputService.srv 
-   StateService.srv
- )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
-## Generate added messages and services with any dependencies listed here
- generate_messages(
-   DEPENDENCIES
-   std_msgs
- )
-
-################################################
-## Declare ROS dynamic reconfigure parameters ##
-################################################
-
-## To declare and build dynamic reconfigure parameters within this
-## package, follow these steps:
-## * In the file package.xml:
-##   * add a build_depend and a run_depend tag for "dynamic_reconfigure"
-## * In this file (CMakeLists.txt):
-##   * add "dynamic_reconfigure" to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * uncomment the "generate_dynamic_reconfigure_options" section below
-##     and list every .cfg file to be processed
-
-## Generate dynamic reconfigure parameters in the 'cfg' folder
-# generate_dynamic_reconfigure_options(
-#   cfg/DynReconf1.cfg
-#   cfg/DynReconf2.cfg
-# )
-
-###################################
-## catkin specific configuration ##
-###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if you package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-#  INCLUDE_DIRS include
+  INCLUDE_DIRS include
 #  LIBRARIES ros_assignments
 #  CATKIN_DEPENDS roscpp std_msgs
 #  DEPENDS system_lib
 )
 
-###########
-## Build ##
-###########
-
-## Specify additional locations of header files
-## Your package locations should be listed before other locations
-# include_directories(include)
 include_directories(
+  include
   ${catkin_INCLUDE_DIRS}
 )
 
@@ -160,3 +73,14 @@ target_link_libraries(state_machine_querry ${catkin_LIBRARIES})
 add_executable(state_machine_input src/${PROJECT_NAME}/state_machine_input.cpp)
 add_dependencies(state_machine_input ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(state_machine_input ${catkin_LIBRARIES})
+
+set(TEST_SRCS
+  test/main.cpp
+  test/${PROJECT_NAME}/triangle_generator.cpp
+)
+
+catkin_add_gtest(${PROJECT_NAME}-test ${TEST_SRCS})
+if(TARGET ${PROJECT_NAME}-test)
+  target_link_libraries(${PROJECT_NAME}-test ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES})
+endif()
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+## Unit tests
+### Running unit tests
+We use Google's unit testing framework called ```googletest``` or ```gtest```. There are two interesting pages documenting ```gtest```
+
+* https://github.com/google/googletest/blob/master/googletest/docs/Primer.md
+* https://github.com/google/googletest/blob/master/googletest/docs/AdvancedGuide.md
+
+The ```catkin``` build system of ```ROS``` comes with a built in ```gtest``` to run unit tests. Envoke tests for all packages in your workspace like this:
+```shell
+catkin_make run_tests
+```
+
+### Unit tests guidelines
+The various tests are usually put into the sub-directory ```test``` of a ```ROS``` package. 
+
+```gtest``` is usually used for testing ROS-agnostic computations, i.e. computations that can be done without the help of other ```ROS``` nodes.
+
+In order to maximize the test coverage of your packages, you can separate computations into ROS-agnostic and ROS-dependent functionalities. For an example look at the class ```TriangleGenerator``` in this package.

--- a/include/ros_assignments/triangle_generator.hpp
+++ b/include/ros_assignments/triangle_generator.hpp
@@ -1,0 +1,87 @@
+#ifndef ROS_ASSIGNMENTS_TRIANGLE_GENERATOR_HPP
+#define ROS_ASSIGNMENTS_TRIANGLE_GENERATOR_HPP
+
+#include <exception>
+
+namespace ros_assignments
+{
+  class TriangleGenerator
+  {
+    public:
+      TriangleGenerator(float amplitude = 1.0, double increment = 0.1,
+          float epsilon = 0.005) : 
+        amplitude_(amplitude), increment_(increment), epsilon_(epsilon)
+      {
+        reset();
+      }
+
+      ~TriangleGenerator() {}
+  
+      float current_value() const
+      {
+        check_parameters();
+
+        float result;
+
+        if ((amplitude_ - last_value_) < epsilon_ && raising_slope_)
+        {
+          result = last_value_ - increment_;
+        }
+        else if ( last_value_ < amplitude_ && raising_slope_)
+        {
+          result = last_value_ + increment_;
+        }
+        else if (last_value_ < epsilon_ && !raising_slope_)
+        {
+          result = last_value_ + increment_;
+        }
+        else if (last_value_ > 0.0 && !raising_slope_)
+        {
+          result = last_value_ - increment_;
+        }
+        return result;
+      }
+
+      void check_parameters() const
+      {
+        if (amplitude_ <= 0.0)
+          throw std::runtime_error("Given non-positive amplitude.");
+        if (epsilon_ <= 0.0)
+          throw std::runtime_error("Given non-positive epsilon.");
+        if (increment_ <= 0.0)
+          throw std::runtime_error("Given non-positive increment.");
+        if (increment_ > amplitude_)
+          throw std::runtime_error("Given increment that is bigger than amplitude.");
+        if (epsilon_ > increment_)
+          throw std::runtime_error("Given epsilon that is bigger than increment.");
+      }
+
+      void step_forward()
+      {
+        float value = current_value();
+
+        if ((amplitude_ - last_value_) < epsilon_ && raising_slope_)
+        {
+          raising_slope_= false;
+        }
+        else if (last_value_ < epsilon_ && !raising_slope_)
+        {
+          raising_slope_ = true;
+        }
+
+        last_value_ = value;
+      }
+
+      void reset()
+      {
+        last_value_ = 0.0;
+        raising_slope_ = true;
+      }
+
+    private:
+      float last_value_, amplitude_, increment_, epsilon_;
+      bool raising_slope_;
+  };
+}
+
+#endif // ROS_ASSIGNMENTS_TRIANGLE_GENERATOR_HPP

--- a/include/ros_assignments/triangle_generator_node.hpp
+++ b/include/ros_assignments/triangle_generator_node.hpp
@@ -1,0 +1,41 @@
+#ifndef ROS_ASSIGNMENTS_TRIANGLE_GENERATOR_NODE_HPP
+#define ROS_ASSIGNMENTS_TRIANGLE_GENERATOR_NODE_HPP
+
+#include <ros/ros.h>
+#include <std_msgs/Float32.h>
+#include <ros_assignments/triangle_generator.hpp>
+
+namespace ros_assignments
+{
+  class TriangleGeneratorNode
+  {
+    public:
+      TriangleGeneratorNode(const ros::NodeHandle& nh): nh_(nh)
+      {}
+  
+      ~TriangleGeneratorNode() {}
+  
+      void start(const ros::Duration& period)
+      {
+        pub_ = nh_.advertise<std_msgs::Float32>("raw", 1);
+        timer_ = nh_.createTimer(period, &TriangleGeneratorNode::callback, this);
+      }
+  
+    private:
+      ros::NodeHandle nh_;
+      ros::Publisher pub_;
+      ros::Timer timer_;
+      TriangleGenerator generator_;
+  
+      void callback(const ros::TimerEvent& e)
+      {
+      	std_msgs::Float32 msg;
+        msg.data = generator_.current_value();
+        generator_.step_forward();
+        ROS_INFO("%f", msg.data);
+        pub_.publish(msg);
+      }
+  };
+}
+
+#endif // ROS_ASSIGNMENTS_TRIANGLE_GENERATOR_NODE_HPP

--- a/package.xml
+++ b/package.xml
@@ -46,6 +46,7 @@
   <run_depend>message_runtime</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
+  <test_depend>gtest</test_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/src/ros_assignments/triangle_generator.cpp
+++ b/src/ros_assignments/triangle_generator.cpp
@@ -1,67 +1,11 @@
-#include <ros/ros.h>
-#include <exception>
-#include <std_msgs/Float32.h>
-#include <deque>
-
-
-class TriangleGenerator
-{
-  public:
-    TriangleGenerator(const ros::NodeHandle& nh): nh_(nh), y_(0.0), amp_(1.0), k_(0)
-    {}
-
-    ~TriangleGenerator() {}
-
-    void start(const ros::Duration& period)
-    {
-      pub_ = nh_.advertise<std_msgs::Float32>("raw", 1);
-      timer_ = nh_.createTimer(period, &TriangleGenerator::callback, this);
-    }
-
-  private:
-    ros::NodeHandle nh_;
-    ros::Publisher pub_;
-    ros::Timer timer_;
-    float y_, amp_;
-    int	k_;
-
-
-    void callback(const ros::TimerEvent& e)
-    {
-        if(y_<amp_ && k_ == 0)
-        {
-        	y_ += 0.1;
-        }
-        else if((amp_ - y_) < 0.005)
-        {
-        	y_ -= 0.1;
-        	k_ = 1;
-        }
-        else if(y_<amp_ && k_ == 1)
-        {
-           	y_ -= 0.1;
-        }
-
-        if(y_ < 0.005 && k_ == 1)
-        {
-        	y_ += 0.1;
-        	k_ = 0;
-        }
-
-    	std_msgs::Float32 msg;
-        msg.data = y_;
-        ROS_INFO("%f", msg.data);
-        pub_.publish(msg);
-    }
-};
-
+#include <ros_assignments/triangle_generator_node.hpp>
 
 int main(int argc, char **argv)
 {
     ros::init(argc, argv, "triangle_generator");
     ros::NodeHandle nh("~");
 
-    TriangleGenerator my_generator(nh);
+    ros_assignments::TriangleGeneratorNode my_generator(nh);
     try
     {
       my_generator.start(ros::Duration(0.1));

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,0 +1,7 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/ros_assignments/triangle_generator.cpp
+++ b/test/ros_assignments/triangle_generator.cpp
@@ -1,0 +1,41 @@
+#include <gtest/gtest.h>
+#include <ros_assignments/triangle_generator.hpp>
+
+class TriangleGeneratorTest : public ::testing::Test
+{
+  protected:
+    virtual void SetUp()
+    {
+      // initialize your global testing variables here
+    }
+
+    virtual void TearDown()
+    {
+      // destroy your global testing variables here
+    }
+
+    // define your global testing variables here
+};
+
+TEST_F(TriangleGeneratorTest, RunTest)
+{
+  ros_assignments::TriangleGenerator my_triangle;
+  for(size_t i=1; i<11; ++i)
+  {
+    EXPECT_NEAR(my_triangle.current_value(), 0.1*i, 1e-06);
+    EXPECT_NO_THROW(my_triangle.step_forward());
+  }
+
+  for(size_t i=9; i>0; --i)
+  {
+    EXPECT_NEAR(my_triangle.current_value(), 0.1*i, 1e-06);
+    EXPECT_NO_THROW(my_triangle.step_forward());
+  }
+
+  for(size_t i=0; i<11; ++i)
+  {
+    EXPECT_NEAR(my_triangle.current_value(), 0.1*i, 1e-06);
+    EXPECT_NO_THROW(my_triangle.step_forward());
+  }
+
+}


### PR DESCRIPTION
@cristiiacob I refactored the triangle generator. I had two goals
(1) Point out some small corrections.
(2) Show how I'd like to use google's unit testing framework to test my code.

There are now 2 new header files. You can find them in the sub-directory include/ros_assignments. 

Please first have a look at TriangleGenerator.hpp. The files holds the definition and declaration of a class that only generates a triangle signal. A couple of things about this class:
- The code in this file is surrounded by a combination of macros like this: `#ifndef SYMBOL #define SYMBOL #endif`. This prevents conflicts in case the same header file is included twice within the same executable. Note, the specific choice of `SYMBOL` does not matter, as long as it is unique.
- The class is kept in a namespace that is the same as the name of package. Namespaces are important to prevent name conflicts between classes and functions.
- I separated the calculation of the signal value from updating the state of the generator. To me, this makes it easier to think about the class.
- I prefer using longer variables names instead of variables with just a single letter.
- The class does not use any functionality from ROS. This makes it very easy to test this class with Google's unit testing framework `gtest`

In the file TriangleGeneratorNode.hpp is a class which takes care of all our ROS communication. Internally, it uses TriangleGenerator.hpp.

Finally, TriangleGenerator.cpp is almost empty as it just uses the class from TriangleGeneratorNode.hpp.

There is one short unit-test testing the code from TriangleGenerator.hpp. You can find it in test/ros_assignments/triangle_generator.cpp. I put some useful information about unit testing into the README.md of this project. Please read.
